### PR TITLE
Update departure.gemspec

### DIFF
--- a/departure.gemspec
+++ b/departure.gemspec
@@ -7,7 +7,7 @@ require 'departure/version'
 
 # This environment variable is set on CI to facilitate testing with multiple
 # versions of Rails.
-RAILS_DEPENDENCY_VERSION = ENV.fetch('RAILS_VERSION', ['>= 5.2.0', '!= 7.0.0', '< 7.1'])
+RAILS_DEPENDENCY_VERSION = ENV.fetch('RAILS_VERSION', ['>= 5.2.0', '!= 7.0.0', '<= 7.1.2'])
 
 Gem::Specification.new do |spec|
   spec.name          = 'departure'


### PR DESCRIPTION
Adds support for [Rails 7.1.2](https://github.com/rails/rails/releases/tag/v7.1.2)